### PR TITLE
fix api-input in a wrong const

### DIFF
--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -30,7 +30,7 @@ export default class FlagsmithGet extends Command {
   async run(): Promise<void> {
     const {args, flags} = await this.parse(FlagsmithGet)
     const environment = args.environment || process.env.FLAGSMITH_ENVIRONMENT
-    const api = args.api || process.env.FLAGSMITH_ENVIRONMENT
+    const api = flags.api || process.env.FLAGSMITH_ENVIRONMENT
     if (environment) {
       this.log('A flagsmith environment was not specified, run flagsmith get --help for more usage.')
     }


### PR DESCRIPTION
This repo fixes an issue with an -a (api) flag being read from a wrong constant. Instead of agrs, it's under flags.

Issue: flagsmith get [ENVIRONMENT] [-o <value>] **[-a <value>**] 

The **-a value** will not be read by the command/get code because it's inside flags not args.

This PR attempts to fix that.