### PR TITLE
Add optional flag to set identity when fetching flags & fix output logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ EXAMPLES
   $ flagsmith get --o ./my-file.json
 
   $ flagsmith get --a https://flagsmith.example.com/api/v1/
+
+  $ flagsmith get --i Bob
 ```
 
 _See code: [dist/commands/get/index.ts](https://github.com/Flagsmith/flagsmith-cli/blob/v0.1.0/dist/commands/get/index.ts)_
@@ -366,14 +368,15 @@ Retrieve Flagsmith features from the Flagsmith API and output them to a file.
 
 ```
 USAGE
-  $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>]
+  $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>]
 
 ARGUMENTS
   ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT
 
 FLAGS
-  -a, --api=<value>     The API URL to fetch the feature flags from
-  -o, --output=<value>  [default: ./flagsmith.json] The file path output
+  -a, --api=<value>       The API URL to fetch the feature flags from
+  -i, --identity=<value>  The identity for which to fetch feature flags
+  -o, --output=<value>    [default: ./flagsmith.json] The file path output
 
 DESCRIPTION
   Retrieve flagsmith features from the Flagsmith API and output them to a file.

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -1,4 +1,4 @@
-import {Command, Flags} from '@oclif/core'
+import { Command, Flags } from '@oclif/core'
 import fetch from 'node-fetch'
 import flagsmith from 'flagsmith/isomorphic'
 const fs = require('fs')
@@ -10,6 +10,7 @@ export default class FlagsmithGet extends Command {
     '$ flagsmith get <ENVIRONMENT_ID>',
     '$ flagsmith get --o ./my-file.json',
     '$ flagsmith get --a https://flagsmith.example.com/api/v1/',
+    '$ flagsmith get --i Bob',
   ]
 
   static flags = {
@@ -18,6 +19,9 @@ export default class FlagsmithGet extends Command {
     }),
     api: Flags.string({
       char: 'a', description: 'The API URL to fetch the feature flags from', required: false,
+    }),
+    identity: Flags.string({
+      char: 'i', description: 'The identity for which to fetch feature flags', required: false,
     }),
   }
 
@@ -28,20 +32,26 @@ export default class FlagsmithGet extends Command {
   ]
 
   async run(): Promise<void> {
-    const {args, flags} = await this.parse(FlagsmithGet)
+    const { args, flags } = await this.parse(FlagsmithGet)
     const environment = args.environment || process.env.FLAGSMITH_ENVIRONMENT
     const api = flags.api || process.env.FLAGSMITH_ENVIRONMENT
-    if (environment) {
+    if (!environment) {
       this.log('A flagsmith environment was not specified, run flagsmith get --help for more usage.')
     }
-
+    const identity = flags.identity;
+    let outputString = `Flagsmith: Retrieving flags from ${environment}`
+    if (identity) {
+      outputString += ` for identity ${identity}`
+    }
     const output = flags.output
-    this.log(`Flagsmith: Retrieving flags from ${environment}, outputing to ${output}.`)
+    outputString += `, outputing to ${output}.`
+    this.log(outputString)
 
     await flagsmith.init({
       environmentID: environment,
       fetch: fetch,
-      api,
+      api: api,
+      identity: identity,
     })
     fs.writeFileSync(output, JSON.stringify(flagsmith.getState()))
   }


### PR DESCRIPTION
This PR adds a new optional `-i` flag to the `flagsmith get` command, which allows users to specify a identity used for fetching flags.