### PR TITLE
chore: Support local evaluation mode with serverside key

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ USAGE
   $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>]
 
 ARGUMENTS
-  ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT
+  ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT, providing a server-side key will fetch the environment document
 
 FLAGS
-  -a, --api=<value>       The API URL to fetch the feature flags from, providing a server-side key will fetch the environment document.
+  -a, --api=<value>       The API URL to fetch the feature flags from.
   -i, --identity=<value>  The identity for which to fetch feature flags
   -o, --output=<value>    [default: ./flagsmith.json] The file path output
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Retrieve flagsmith features from the Flagsmith API and output them to a file.
 
 ```
 USAGE
-  $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>] [-p] [-e flags|document]
+  $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>] [-p] [-e flags|environment]
 
 ARGUMENTS
   ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT
@@ -81,7 +81,7 @@ FLAGS
   -e, --entity=<option>   [default: flags] The entity to fetch, this will either be the flags or an environment document
                           used for [local evaluation](https://docs.flagsmith.com/clients/server-side#local-evaluation-mo
                           de-network-behaviour).
-                          <options: flags|document>
+                          <options: flags|environment>
   -i, --identity=<value>  The identity for which to fetch feature flags
   -o, --output=<value>    [default: ./flagsmith.json] The file path output
   -p, --pretty            Prettify the output JSON
@@ -94,7 +94,7 @@ EXAMPLES
 
   $ FLAGSMITH_ENVIRONMENT=x flagsmith get
 
-  $ flagsmith get -e document
+  $ flagsmith get -e environment
 
   $ flagsmith get -o ./my-file.json
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ USAGE
   $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>]
 
 ARGUMENTS
-  ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT, providing a server-side key will fetch the environment document
+  ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT, providing a server-side key will fetch the environment document.
 
 FLAGS
   -a, --api=<value>       The API URL to fetch the feature flags from.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ARGUMENTS
   ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT, providing a server-side key will fetch the environment document.
 
 FLAGS
-  -a, --api=<value>       The API URL to fetch the feature flags from.
+  -a, --api=<value>       The API URL to fetch the feature flags from
   -i, --identity=<value>  The identity for which to fetch feature flags
   -o, --output=<value>    [default: ./flagsmith.json] The file path output
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ npm install -g flagsmith-cli
 $ flagsmith COMMAND
 running command...
 $ flagsmith (--version)
-flagsmith-cli/0.1.4 darwin-arm64 node-v18.16.0
+flagsmith-cli/0.1.2 darwin-arm64 node-v18.13.0
 $ flagsmith --help [COMMAND]
 USAGE
   $ flagsmith COMMAND
@@ -64,15 +64,6 @@ USAGE
 <!-- commands -->
 * [`flagsmith get [ENVIRONMENT]`](#flagsmith-get-environment)
 * [`flagsmith help [COMMANDS]`](#flagsmith-help-commands)
-* [`flagsmith plugins`](#flagsmith-plugins)
-* [`flagsmith plugins:install PLUGIN...`](#flagsmith-pluginsinstall-plugin)
-* [`flagsmith plugins:inspect PLUGIN...`](#flagsmith-pluginsinspect-plugin)
-* [`flagsmith plugins:install PLUGIN...`](#flagsmith-pluginsinstall-plugin-1)
-* [`flagsmith plugins:link PLUGIN`](#flagsmith-pluginslink-plugin)
-* [`flagsmith plugins:uninstall PLUGIN...`](#flagsmith-pluginsuninstall-plugin)
-* [`flagsmith plugins:uninstall PLUGIN...`](#flagsmith-pluginsuninstall-plugin-1)
-* [`flagsmith plugins:uninstall PLUGIN...`](#flagsmith-pluginsuninstall-plugin-2)
-* [`flagsmith plugins update`](#flagsmith-plugins-update)
 
 ## `flagsmith get [ENVIRONMENT]`
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ npm install -g flagsmith-cli
 $ flagsmith COMMAND
 running command...
 $ flagsmith (--version)
-flagsmith-cli/0.1.2 darwin-arm64 node-v18.13.0
+flagsmith-cli/0.1.4 darwin-arm64 node-v18.16.0
 $ flagsmith --help [COMMAND]
 USAGE
   $ flagsmith COMMAND
@@ -64,39 +64,57 @@ USAGE
 <!-- commands -->
 * [`flagsmith get [ENVIRONMENT]`](#flagsmith-get-environment)
 * [`flagsmith help [COMMANDS]`](#flagsmith-help-commands)
-  
+* [`flagsmith plugins`](#flagsmith-plugins)
+* [`flagsmith plugins:install PLUGIN...`](#flagsmith-pluginsinstall-plugin)
+* [`flagsmith plugins:inspect PLUGIN...`](#flagsmith-pluginsinspect-plugin)
+* [`flagsmith plugins:install PLUGIN...`](#flagsmith-pluginsinstall-plugin-1)
+* [`flagsmith plugins:link PLUGIN`](#flagsmith-pluginslink-plugin)
+* [`flagsmith plugins:uninstall PLUGIN...`](#flagsmith-pluginsuninstall-plugin)
+* [`flagsmith plugins:uninstall PLUGIN...`](#flagsmith-pluginsuninstall-plugin-1)
+* [`flagsmith plugins:uninstall PLUGIN...`](#flagsmith-pluginsuninstall-plugin-2)
+* [`flagsmith plugins update`](#flagsmith-plugins-update)
+
 ## `flagsmith get [ENVIRONMENT]`
 
 Retrieve flagsmith features from the Flagsmith API and output them to a file.
 
 ```
 USAGE
-  $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>]
+  $ flagsmith get [ENVIRONMENT] [-o <value>] [-a <value>] [-i <value>] [-p] [-e flags|document]
 
 ARGUMENTS
-  ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT, providing a server-side key will fetch the environment document.
+  ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT
 
 FLAGS
   -a, --api=<value>       The API URL to fetch the feature flags from
+  -e, --entity=<option>   [default: flags] The entity to fetch, this will either be the flags or an environment document
+                          used for [local evaluation](https://docs.flagsmith.com/clients/server-side#local-evaluation-mo
+                          de-network-behaviour).
+                          <options: flags|document>
   -i, --identity=<value>  The identity for which to fetch feature flags
   -o, --output=<value>    [default: ./flagsmith.json] The file path output
+  -p, --pretty            Prettify the output JSON
 
 DESCRIPTION
   Retrieve flagsmith features from the Flagsmith API and output them to a file.
 
 EXAMPLES
-  $ FLAGSMITH_ENVIRONMENT=x flagsmith get
-
   $ flagsmith get <ENVIRONMENT_API_KEY>
 
-  $ flagsmith get --o ./my-file.json
+  $ FLAGSMITH_ENVIRONMENT=x flagsmith get
 
-  $ flagsmith get --a https://flagsmith.example.com/api/v1/
+  $ flagsmith get -e document
 
-  $ flagsmith get --i flagsmith_identity
+  $ flagsmith get -o ./my-file.json
+
+  $ flagsmith get -a https://flagsmith.example.com/api/v1/
+
+  $ flagsmith get -i flagsmith_identity
+
+  $ flagsmith get -p
 ```
 
-_See code: [dist/commands/get/index.ts](https://github.com/Flagsmith/flagsmith-cli/blob/v0.1.2/dist/commands/get/index.ts)_
+_See code: [dist/commands/get/index.ts](https://github.com/Flagsmith/flagsmith-cli/blob/v0.1.4/dist/commands/get/index.ts)_
 
 ## `flagsmith help [COMMANDS]`
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ARGUMENTS
   ENVIRONMENT  The flagsmith environment key to use, defaults to the environment variable FLAGSMITH_ENVIRONMENT
 
 FLAGS
-  -a, --api=<value>       The API URL to fetch the feature flags from
+  -a, --api=<value>       The API URL to fetch the feature flags from, providing a server-side key will fetch the environment document.
   -i, --identity=<value>  The identity for which to fetch feature flags
   -o, --output=<value>    [default: ./flagsmith.json] The file path output
 
@@ -87,7 +87,7 @@ DESCRIPTION
 EXAMPLES
   $ FLAGSMITH_ENVIRONMENT=x flagsmith get
 
-  $ flagsmith get <ENVIRONMENT_ID>
+  $ flagsmith get <ENVIRONMENT_API_KEY>
 
   $ flagsmith get --o ./my-file.json
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A CLI allowing you to fetch Flagsmith flags and output them to a file",
   "author": "kyle-ssg @kyle-ssg",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-cli",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "A CLI allowing you to fetch Flagsmith flags and output them to a file",
   "author": "kyle-ssg @kyle-ssg",
   "bin": {

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -68,7 +68,7 @@ export default class FlagsmithGet extends Command {
     this.log(outputString)
 
     if (isDocument) {
-      fetch(`${api || 'https://edge.api.flagsmith.com/api/v1/'}environment-document/flags/`, {
+      fetch(`${api || 'https://edge.api.flagsmith.com/api/v1/'}environment-document/`, {
         headers: {
           'x-environment-key': environment,
         },

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -67,7 +67,7 @@ export default class FlagsmithGet extends Command {
     outputString += `, outputing to ${output}.`
     this.log(outputString)
 
-    if (environment?.startsWith('ser.')) {
+    if (isDocument) {
       fetch(`${api || 'https://edge.api.flagsmith.com/api/v1/'}environment-document/flags/`, {
         headers: {
           'x-environment-key': environment,

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -8,7 +8,7 @@ export default class FlagsmithGet extends Command {
   static examples = [
     '$ flagsmith get <ENVIRONMENT_API_KEY>',
     '$ FLAGSMITH_ENVIRONMENT=x flagsmith get',
-    '$ flagsmith get -e document',
+    '$ flagsmith get -e environment',
     '$ flagsmith get -o ./my-file.json',
     '$ flagsmith get -a https://flagsmith.example.com/api/v1/',
     '$ flagsmith get -i flagsmith_identity',
@@ -29,7 +29,7 @@ export default class FlagsmithGet extends Command {
       char: 'p', description: 'Prettify the output JSON', required: false, default: true,
     }),
     entity: Flags.string({
-      options: ['flags', 'document'],
+      options: ['flags', 'environment'],
       char: 'e',
       description: 'The entity to fetch, this will either be the flags or an environment document used for [local evaluation](https://docs.flagsmith.com/clients/server-side#local-evaluation-mode-network-behaviour).', required: false, default: 'flags',
     }),
@@ -57,7 +57,7 @@ export default class FlagsmithGet extends Command {
 
     const output = flags.output
     const entity = flags.entity
-    const isDocument = entity === 'document'
+    const isDocument = entity === 'environment'
 
     if (isDocument && !environment?.startsWith('ser.')) {
       this.error('In order to fetch the environment document you need to provide a server-side SDK token.')

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -52,16 +52,30 @@ export default class FlagsmithGet extends Command {
     outputString += `, outputing to ${output}.`
     this.log(outputString)
 
-    await flagsmith.init({
-      environmentID: environment,
-      fetch: fetch,
-      api: api,
-      identity: identity,
-    })
-    if (flags.pretty) {
-      fs.writeFileSync(output, JSON.stringify(flagsmith.getState(), null, 2))
+    if (environment?.startsWith('ser.')) {
+      fetch(`${api || 'https://edge.api.flagsmith.com/api/v1/'}environment-document/flags/`, {
+        headers: {
+          'x-environment-key': environment,
+        },
+      }).then(res => res.json()).then(res => {
+        if (flags.pretty) {
+          fs.writeFileSync(output, JSON.stringify(res, null, 2))
+        } else {
+          fs.writeFileSync(output, JSON.stringify(res))
+        }
+      })
     } else {
-      fs.writeFileSync(output, JSON.stringify(flagsmith.getState()))
+      await flagsmith.init({
+        environmentID: environment,
+        fetch: fetch,
+        api: api,
+        identity: identity,
+      })
+      if (flags.pretty) {
+        fs.writeFileSync(output, JSON.stringify(flagsmith.getState(), null, 2))
+      } else {
+        fs.writeFileSync(output, JSON.stringify(flagsmith.getState()))
+      }
     }
   }
 }


### PR DESCRIPTION
This makes it so that supplying a server-side api token outputs the environment document rather than just the feature evaluations.


This is necessary for the [following PR in App ](https://github.com/Flagsmith/flagsmith/compare/chore/export-features?expand=1)