### PR TITLE
fix: update flagsmith to 9.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A CLI allowing you to fetch Flagsmith flags and output them to a file",
   "author": "kyle-ssg @kyle-ssg",
   "bin": {
@@ -20,7 +20,7 @@
     "@oclif/core": "^1.16.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.0.1",
-    "flagsmith": "3.9.1",
+    "flagsmith": "^9.0.5",
     "node-fetch": "^2.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
this fixes the issue with the conflicting ts field type as reported in https://github.com/Flagsmith/flagsmith-js-client/issues/292