### PR TITLE
fix: Prevent identity fetch when traits and identity are undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "shx": "^0.3.3",
     "ts-node": "^10.2.1",
     "tslib": "^2.3.1",
-    "typescript": "5.8.2"
+    "typescript": "4.4.4"
   },
   "oclif": {
     "bin": "flagsmith",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flagsmith-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A CLI allowing you to fetch Flagsmith flags and output them to a file",
   "author": "kyle-ssg @kyle-ssg",
   "bin": {
@@ -39,7 +39,7 @@
     "shx": "^0.3.3",
     "ts-node": "^10.2.1",
     "tslib": "^2.3.1",
-    "typescript": "4.4.4"
+    "typescript": "5.8.2"
   },
   "oclif": {
     "bin": "flagsmith",

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -72,11 +72,16 @@ export default class FlagsmithGet extends Command {
       outputString += ` for identity ${identity}`
     }
 
-    const traits : Record<string, string> = {}
-    for (const t of flags.trait || []) {
-      const [k, v] = t.split(/=(.*)/s)
-      traits[k] = v
+    let traits : Record<string, string> | undefined = undefined
+
+    if(flags.trait) {
+      traits = {}
+      for (const t of flags.trait || []) {
+        const [k, v] = t.split(/=(.*)/s)
+        traits[k] = v
+      }
     }
+
 
     const output = flags.output
     const entity = flags.entity
@@ -103,6 +108,13 @@ export default class FlagsmithGet extends Command {
         }
       })
     } else {
+      console.log("INIT", {
+        environmentID: environment,
+        fetch: fetch,
+        api: api,
+        identity: identity,
+        traits: traits,
+      })
       await flagsmith.init({
         environmentID: environment,
         fetch: fetch,

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -82,7 +82,6 @@ export default class FlagsmithGet extends Command {
       }
     }
 
-
     const output = flags.output
     const entity = flags.entity
     const isDocument = entity === 'environment'

--- a/src/commands/get/index.ts
+++ b/src/commands/get/index.ts
@@ -108,13 +108,6 @@ export default class FlagsmithGet extends Command {
         }
       })
     } else {
-      console.log("INIT", {
-        environmentID: environment,
-        fetch: fetch,
-        api: api,
-        identity: identity,
-        traits: traits,
-      })
       await flagsmith.init({
         environmentID: environment,
         fetch: fetch,


### PR DESCRIPTION
Fixes an issue where the CLI was incorrectly trying to identify as an anonymous user when identity/traits was undefined

## How to test
- run flagsmith get <ENV_ID>, it generates an identity in the response due to traits being {} vs undefined