### PR TITLE
ci: build release binaries with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # upload release artifacts
+      id-token: write # attest artifacts
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -26,3 +28,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Attests every file listed in the checksum file.
+      - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-checksums: ./dist/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,10 @@ jobs:
       - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-checksums: ./dist/checksums.txt
+
+      # During public beta the newest beta is what people
+      # should land on, so clear it.
+      - if: contains(github.ref_name, '-beta')
+        run: gh release edit "$GITHUB_REF_NAME" --prerelease=false --latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # upload release artifacts
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,10 +6,9 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
-    # .Tag, not .Version: `flagsmith --version` should print the tag verbatim,
-    # and internal/version.IsRelease expects the leading v.
     ldflags:
-      - -s -w -X github.com/Flagsmith/flagsmith-cli/internal/version.Version={{ .Tag }}
+      - >-
+        -s -w -X github.com/Flagsmith/flagsmith-cli/internal/version.Version={{ if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}
     mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,5 +39,5 @@ changelog:
   disable: true
 
 release:
-  mode: append
+  mode: keep-existing
   prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,43 @@
+version: 2
+
+builds:
+  - binary: flagsmith
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    # .Tag, not .Version: `flagsmith --version` should print the tag verbatim,
+    # and internal/version.IsRelease expects the leading v.
+    ldflags:
+      - -s -w -X github.com/Flagsmith/flagsmith-cli/internal/version.Version={{ .Tag }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: "flagsmith_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+
+# changelog handled by release-please.
+changelog:
+  disable: true
+
+release:
+  mode: append
+  prerelease: auto


### PR DESCRIPTION
Contributes to #45

### Verified locally

- `goreleaser check` clean.
- `goreleaser release --snapshot --clean --skip=publish` built all six targets and packaged them; archives contain `flagsmith`, `LICENSE`, `README.md`.
- The darwin/arm64 binary prints `flagsmith version v1.1.0` — the stamp resolves through the `internal/version.Version` ldflags path.

Also attests the archives: `actions/attest` with `subject-checksums` covers every file listed in `checksums.txt`. Verify with `gh attestation verify --owner Flagsmith <file>`.
