### PR TITLE
ci: publish multi-arch images to ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # upload release artifacts
+      packages: write # push to ghcr.io
       id-token: write # attest artifacts
       attestations: write
     steps:
@@ -22,6 +23,12 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"
@@ -32,6 +39,9 @@ jobs:
       - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-checksums: ./dist/checksums.txt
+      - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-checksums: ./dist/digests.txt
 
       # During public beta the newest beta is what people
       # should land on, so clear it.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,27 @@ archives:
 checksum:
   name_template: checksums.txt
 
+docker_digest:
+  name_template: digests.txt
+
+dockers_v2:
+  - images:
+      - ghcr.io/flagsmith/flagsmith-cli
+    tags:
+      - "{{ .Tag }}"
+      - "{{ .Version }}"
+      # Beta releases still take :latest — nothing stabler is published yet.
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      # Links the ghcr package to this repo.
+      org.opencontainers.image.source: https://github.com/Flagsmith/flagsmith-cli
+      org.opencontainers.image.version: "{{ .Tag }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: MIT
+
 # changelog handled by release-please.
 changelog:
   disable: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM --platform=$BUILDPLATFORM alpine:3 AS certs
+RUN apk add --no-cache ca-certificates
+
+FROM alpine:3
+ARG TARGETPLATFORM
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY $TARGETPLATFORM/flagsmith /usr/local/bin/flagsmith
+WORKDIR /work
+ENTRYPOINT ["flagsmith"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The next-generation Flagsmith command-line interface (work in progress).
 go build -o flagsmith .
 ```
 
+## Docker
+
+```sh
+docker run --rm -v "$PWD:/work" -e FLAGSMITH_API_KEY ghcr.io/flagsmith/flagsmith-cli flag list
+```
+
+A container has no keyring, so `flagsmith login` cannot store credentials there — pass `FLAGSMITH_API_KEY` or `FLAGSMITH_ENVIRONMENT_KEY`.
+
 ## Quickstart
 
 ```sh


### PR DESCRIPTION
Closes #45.

### Verified locally

- `goreleaser release --snapshot --clean --skip=publish` built both per-arch images.
- Ran the arm64 image: `flagsmith version v1.1.0`, cert bundle present at `/etc/ssl/certs/ca-certificates.crt`, and a request reached `edge.api.flagsmith.com` over TLS — so the trust store works.

### Important

- After the first publish the ghcr package needs to be made public by hand.
- No `:main` tag yet: `dockers_v2` only runs on a tag.

`docker_digest` writes `digests.txt` so the images get attested too. That step is the one thing here I could not verify locally — snapshot mode publishes nothing, so no digest file exists until a real tag.
