### PR TITLE
fix(build): `go install` doesn't work as documented

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ builds:
       - -trimpath
     ldflags:
       - >-
-        -s -w -X github.com/Flagsmith/flagsmith-cli/internal/version.Version={{ if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}
+        -s -w -X github.com/Flagsmith/flagsmith-cli/v2/internal/version.Version={{ if .IsSnapshot }}v{{ .Version }}{{ else }}{{ .Tag }}{{ end }}
     mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/Flagsmith/flagsmith-cli/main/instal
 
 To pin the installer itself, fetch it at a commit you trust: `raw.githubusercontent.com/Flagsmith/flagsmith-cli/<sha>/install.sh`.
 
-Alternatively, `go install github.com/Flagsmith/flagsmith-cli@latest`, or grab an archive from [Releases](https://github.com/Flagsmith/flagsmith-cli/releases).
+Alternatively, `go install github.com/Flagsmith/flagsmith-cli/v2@v2.0.0-beta.1` (installs as `flagsmith-cli`), or grab an archive from [Releases](https://github.com/Flagsmith/flagsmith-cli/releases). <!-- x-release-please-version -->
 
 On Windows:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Flagsmith/flagsmith-cli
+module github.com/Flagsmith/flagsmith-cli/v2
 
 go 1.26
 

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ detect_platform() {
 	case "$ARCH" in
 	x86_64 | amd64) ARCH=amd64 ;;
 	aarch64 | arm64) ARCH=arm64 ;;
-	*) err "unsupported architecture '${ARCH}' — 'go install github.com/${REPO}@${VERSION}' builds from source" ;;
+	*) err "unsupported architecture '${ARCH}' — 'go install github.com/${REPO}/v2@${VERSION}' builds from source" ;;
 	esac
 
 	# uname reports x86_64 under Rosetta.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -13,10 +13,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/httpx"
-	"github.com/Flagsmith/flagsmith-cli/internal/version"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/httpx"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/version"
 )
 
 // Auth applies an Authorization scheme to a request.

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
 )
 
 const (

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
 
 	"github.com/zalando/go-keyring"
 )

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -13,11 +13,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var (

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 const (

--- a/internal/cmd/client.go
+++ b/internal/cmd/client.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/httpx"
-	"github.com/Flagsmith/flagsmith-cli/internal/version"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/httpx"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/version"
 )
 
 // userAgent identifies the CLI on every outbound request.

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/zalando/go-keyring"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/config"
-	"github.com/Flagsmith/flagsmith-cli/internal/version"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/config"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/version"
 )
 
 const (

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 // abbreviateHome shortens a path under the user's home directory to a ~ prefix,

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/config"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/config"
 )
 
 const (

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var environmentCmd = &cobra.Command{

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
-	"github.com/Flagsmith/flagsmith-cli/internal/config"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/config"
 )
 
 // A hint is an optional line rendered after an error message (before the usage

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
-	"github.com/Flagsmith/flagsmith-cli/internal/config"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/config"
 )
 
 func TestHintFor(t *testing.T) {

--- a/internal/cmd/feature.go
+++ b/internal/cmd/feature.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var featureCmd = &cobra.Command{

--- a/internal/cmd/flag_identity.go
+++ b/internal/cmd/flag_identity.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 // identityFlagView is the curated shape for a flag's state for one identity.

--- a/internal/cmd/flag_reorder.go
+++ b/internal/cmd/flag_reorder.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var flagReorderCmd = &cobra.Command{

--- a/internal/cmd/flag_update.go
+++ b/internal/cmd/flag_update.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var (

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 // metaFanOut bounds how many per-feature metadata reads run concurrently.

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/config"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
-	"github.com/Flagsmith/flagsmith-cli/internal/version"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/config"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/version"
 )
 
 // schemaURL pins the $schema written by init to the schema of the writing

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -7,9 +7,9 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var noBrowser bool

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 func newLogoutCmd() *cobra.Command {

--- a/internal/cmd/organisation.go
+++ b/internal/cmd/organisation.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var organisationCmd = &cobra.Command{

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 var projectCmd = &cobra.Command{

--- a/internal/cmd/prompts.go
+++ b/internal/cmd/prompts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/prompt"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/prompt"
 )
 
 // stdinIsTTY gates whether prompting is allowed at all; tests stub it.

--- a/internal/cmd/render.go
+++ b/internal/cmd/render.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 // renderList renders a list command's items: as JSON when requested, else the

--- a/internal/cmd/resolve.go
+++ b/internal/cmd/resolve.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
 )
 
 // idNameMap builds a canonical→name map from a fetched slice.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
-	"github.com/Flagsmith/flagsmith-cli/internal/version"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/version"
 )
 
 // annotationLongRunning marks a command that manages its own long wait (e.g. a

--- a/internal/cmd/segment.go
+++ b/internal/cmd/segment.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/cache"
-	"github.com/Flagsmith/flagsmith-cli/internal/output"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/cache"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/output"
 )
 
 // segmentRuleSchema is stamped onto emitted rules so a saved rule file

--- a/internal/cmd/sentinel_test.go
+++ b/internal/cmd/sentinel_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Flagsmith/flagsmith-cli/internal/api"
-	"github.com/Flagsmith/flagsmith-cli/internal/auth"
-	"github.com/Flagsmith/flagsmith-cli/internal/bug"
-	"github.com/Flagsmith/flagsmith-cli/internal/config"
-	"github.com/Flagsmith/flagsmith-cli/internal/prompt"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/api"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/auth"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/bug"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/config"
+	"github.com/Flagsmith/flagsmith-cli/v2/internal/prompt"
 )
 
 // Every exported Err* sentinel must have an explicit hint decision: a hintFor

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is the CLI version: the release tag stamped by the release build
-// (-ldflags "-X github.com/Flagsmith/flagsmith-cli/internal/version.Version=v1.2.3"),
+// (-ldflags "-X github.com/Flagsmith/flagsmith-cli/v2/internal/version.Version=v1.2.3"),
 // else resolved from build info.
 var Version = "dev"
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/Flagsmith/flagsmith-cli/internal/cmd"
+import "github.com/Flagsmith/flagsmith-cli/v2/internal/cmd"
 
 func main() {
 	cmd.Execute()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
             "include-component-in-tag": false,
             "extra-files": [
                 "install.sh",
-                "install.ps1"
+                "install.ps1",
+                "README.md"
             ]
         }
     },


### PR DESCRIPTION
`go install github.com/Flagsmith/flagsmith-cli@latest` resolves v1.1.0 and fails. In go, major ≥2 requires the `/v2` suffix.

- `module github.com/Flagsmith/flagsmith-cli/v2`; imports rewritten, ldflags path updated
- README pins the beta tag, since `@latest` skips prereleases while v1.1.0 exists; release-please keeps the pin current
- `go install` names binaries after the module path, so it lands as `flagsmith-cli`

Verified: build, vet, test, `go mod tidy -diff`, all hooks, and a goreleaser snapshot still stamping the version — a stale ldflags path would silently print `dev`.
