### PR TITLE
ci: Publish a Homebrew cask on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,24 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.FLAGSMITH_ENGINEERING_GH_APP_ID }}
+          private-key: ${{ secrets.FLAGSMITH_ENGINEERING_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+          # Only what the cask needs: push its branch, open the pull request.
+          permission-contents: write
+          permission-pull-requests: write
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       # Attests every file listed in the checksum file.
       - uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,6 +54,32 @@ dockers_v2:
       org.opencontainers.image.revision: "{{ .FullCommit }}"
       org.opencontainers.image.licenses: MIT
 
+homebrew_casks:
+  - name: flagsmith
+    repository:
+      owner: Flagsmith
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+    homepage: https://github.com/Flagsmith/flagsmith-cli
+    description: The Flagsmith command-line interface
+    binaries:
+      - flagsmith
+    generate_completions_from_executable:
+      executable: flagsmith
+      args: [completion]
+      shell_parameter_format: cobra
+      shells: [bash, zsh, fish]
+    hooks:
+      post:
+        # Homebrew quarantines what it downloads;
+        # Unqarantine manually until we start notarising the Mac binaries.
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/flagsmith"]
+          end
+
 # changelog handled by release-please.
 changelog:
   disable: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ The next-generation Flagsmith command-line interface (work in progress).
 ## Install
 
 ```sh
+brew install Flagsmith/tap/flagsmith
+```
+
+Or:
+
+```sh
 curl -fsSL https://raw.githubusercontent.com/Flagsmith/flagsmith-cli/main/install.sh | sh
 ```
 


### PR DESCRIPTION

In this PR, we add support for `brew install Flagsmith/tap/flagsmith`.

Goreleaser is configured to open PRs against Flagsmith/homebrew-tap so Vanta's branch protection rule requirement is maintained. Flagsmith Engineering bot credentials are used.

Prerequisites:
1. Flagsmith/homebrew-tap public repo. Created, accessible to Flagsmith Engineering app.
2. `FLAGSMITH_ENGINEERING_GH_APP_ID` and `..._PRIVATE_KEY` should be set org-level — confirmed.
