### PR TITLE
ci: Publish npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,13 @@ jobs:
         with:
           node-version: 24 # npm >= 11.5.1 required for OIDC trusted publishing
       # TODO: switch to goreleaser-npm-publisher-action once https://github.com/evg4b/goreleaser-npm-publisher/pull/26 is released
-      # Prebuilt dist committed on the fork branch (c1e31d2 + dist/, built and
+      # Prebuilt dist committed on the fork branch (5e09f1e + dist/, built and
       # smoke-tested locally). Deliberately no yarn install/build here: this job
       # holds id-token: write, so third-party install scripts must not run in it.
       - name: Fetch goreleaser-npm-publisher
         run: |
           git clone https://github.com/khvn26/goreleaser-npm-publisher "$RUNNER_TEMP/gnp"
-          git -C "$RUNNER_TEMP/gnp" checkout 5001ba9cbd9795b904c2be3090f161a5392a6651
+          git -C "$RUNNER_TEMP/gnp" checkout ad16d393106b23b6289d0569beefb8e9b3bd3159
       - name: Publish npm packages
         run: >-
           node "$RUNNER_TEMP/gnp/dist/cli.cjs" publish
@@ -73,6 +73,7 @@ jobs:
           --bin flagsmith
           --prefix @flagsmith
           --license MIT
+          --repository 'git+https://github.com/Flagsmith/flagsmith-cli.git'
           --description 'The Flagsmith command-line interface'
           --keywords flagsmith feature-flags cli
           --files README.md LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,14 @@ jobs:
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 24 # npm >= 11.5.1 required for OIDC trusted publishing
-      # TODO: swith to goreleaser-npm-publisher-action once https://github.com/evg4b/goreleaser-npm-publisher/pull/26 is released
-      - name: Build goreleaser-npm-publisher
+      # TODO: switch to goreleaser-npm-publisher-action once https://github.com/evg4b/goreleaser-npm-publisher/pull/26 is released
+      # Prebuilt dist committed on the fork branch (c1e31d2 + dist/, built and
+      # smoke-tested locally). Deliberately no yarn install/build here: this job
+      # holds id-token: write, so third-party install scripts must not run in it.
+      - name: Fetch goreleaser-npm-publisher
         run: |
           git clone https://github.com/khvn26/goreleaser-npm-publisher "$RUNNER_TEMP/gnp"
-          cd "$RUNNER_TEMP/gnp"
-          git checkout c1e31d21c240162920cbf87c62a47e3ce306944a
-          corepack enable
-          yarn install --immutable
-          yarn build
+          git -C "$RUNNER_TEMP/gnp" checkout 5001ba9cbd9795b904c2be3090f161a5392a6651
       - name: Publish npm packages
         run: >-
           node "$RUNNER_TEMP/gnp/dist/cli.cjs" publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,29 @@ jobs:
         with:
           subject-checksums: ./dist/digests.txt
 
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 24 # npm >= 11.5.1 required for OIDC trusted publishing
+      # TODO: swith to goreleaser-npm-publisher-action once https://github.com/evg4b/goreleaser-npm-publisher/pull/26 is released
+      - name: Build goreleaser-npm-publisher
+        run: |
+          git clone https://github.com/khvn26/goreleaser-npm-publisher "$RUNNER_TEMP/gnp"
+          cd "$RUNNER_TEMP/gnp"
+          git checkout c1e31d21c240162920cbf87c62a47e3ce306944a
+          corepack enable
+          yarn install --immutable
+          yarn build
+      - name: Publish npm packages
+        run: >-
+          node "$RUNNER_TEMP/gnp/dist/cli.cjs" publish
+          --name cli
+          --bin flagsmith
+          --prefix @flagsmith
+          --license MIT
+          --description 'The Flagsmith command-line interface'
+          --keywords flagsmith feature-flags cli
+          --files README.md LICENSE
+
       # During public beta the newest beta is what people
       # should land on, so clear it.
       - if: contains(github.ref_name, '-beta')


### PR DESCRIPTION
Contributes to #47.

In this PR, we publish `@flagsmith/cli` and six platform packages from the release workflow, using [goreleaser-npm-publisher](https://github.com/evg4b/goreleaser-npm-publisher) over the GoReleaser `dist/` output.

Auth is npm trusted publishing (OIDC).

Groundwork already done outside this PR:

- The six platform packages are bootstrapped on npm at `0.0.0` placeholders (npm requires a package to exist before trusted publishing can be configured).
- All seven packages have a trusted publisher configured for `Flagsmith/flagsmith-cli` + `release.yml` via `npm trust`. The stale `publish.yml` config on `@flagsmith/cli` (v1 oclif era) was revoked.

The tool is built from a [pinned fork](https://github.com/evg4b/goreleaser-npm-publisher/pull/26) commit because upstream derives the package and command names from the GoReleaser `project_name`, which cannot express package `@flagsmith/cli` + command `flagsmith`.

We'll `npm deprecate @flagsmith/cli@"<2.0.0"` with a docs link once 2.0.0 is released.
