### PR TITLE
fix(install): Warn when another flagsmith on PATH may shadow the install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -84,9 +84,9 @@ function Add-UserPath {
     return $true
 }
 
-# Write-Conflicts reports other flagsmith commands on PATH that may shadow
+# Write-ConflictWarning reports other flagsmith commands on PATH that may shadow
 # (or be shadowed by) the one just installed.
-function Write-Conflicts {
+function Write-ConflictWarning {
     param([string]$Target)
 
     $resolvedTarget = [System.IO.Path]::GetFullPath($Target)
@@ -170,7 +170,7 @@ $exe = Join-Path $BinDir $ExeName
 $installed = & $exe --version
 if ($LASTEXITCODE -ne 0) { throw "$exe was installed but will not run" }
 Write-Output "$verb $installed $prep $exe"
-Write-Conflicts -Target $exe
+Write-ConflictWarning -Target $exe
 
 $pathAdded = $false
 if (-not $NoModifyPath) {

--- a/install.ps1
+++ b/install.ps1
@@ -90,10 +90,13 @@ function Write-ConflictWarning {
     param([string]$Target)
 
     $resolvedTarget = [System.IO.Path]::GetFullPath($Target)
-    $others = @(Get-Command -Name 'flagsmith' -All -ErrorAction SilentlyContinue |
-            Where-Object { $_.Source -and ([System.IO.Path]::GetFullPath($_.Source) -ne $resolvedTarget) })
+    # Application catches flagsmith.exe and npm's flagsmith.cmd shim;
+    # ExternalScript catches its flagsmith.ps1 shim. Both expose .Path, and
+    # neither triggers module auto-loading the way an unfiltered -All can.
+    $others = @(Get-Command -Name 'flagsmith' -CommandType Application, ExternalScript -All -ErrorAction SilentlyContinue |
+            Where-Object { $_.Path -and ([System.IO.Path]::GetFullPath($_.Path) -ne $resolvedTarget) })
     foreach ($other in $others) {
-        Write-Output "warning: another 'flagsmith' is on your PATH at $($other.Source)"
+        Write-Output "warning: another 'flagsmith' is on your PATH at $($other.Path)"
     }
     if ($others.Count -gt 0) {
         Write-Output "It may shadow $Target - uninstall it first ('npm uninstall -g flagsmith-cli' removes the old npm CLI), then open a new terminal."

--- a/install.ps1
+++ b/install.ps1
@@ -84,6 +84,22 @@ function Add-UserPath {
     return $true
 }
 
+# Write-Conflicts reports other flagsmith commands on PATH that may shadow
+# (or be shadowed by) the one just installed.
+function Write-Conflicts {
+    param([string]$Target)
+
+    $resolvedTarget = [System.IO.Path]::GetFullPath($Target)
+    $others = @(Get-Command -Name 'flagsmith' -All -ErrorAction SilentlyContinue |
+            Where-Object { $_.Source -and ([System.IO.Path]::GetFullPath($_.Source) -ne $resolvedTarget) })
+    foreach ($other in $others) {
+        Write-Output "warning: another 'flagsmith' is on your PATH at $($other.Source)"
+    }
+    if ($others.Count -gt 0) {
+        Write-Output "It may shadow $Target - uninstall it first ('npm uninstall -g flagsmith-cli' removes the old npm CLI), then open a new terminal."
+    }
+}
+
 # Add-CiPath makes the CLI available to later steps of a GitHub Actions job.
 function Add-CiPath {
     param([string]$Dir)
@@ -144,6 +160,7 @@ try {
 
     Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    $verb, $prep = if (Test-Path -LiteralPath (Join-Path $BinDir $ExeName)) { 'updated', 'at' } else { 'installed', 'to' }
     Move-Item -Force -LiteralPath (Join-Path $tmp $ExeName) -Destination (Join-Path $BinDir $ExeName)
 } finally {
     Remove-Item -Recurse -Force -LiteralPath $tmp
@@ -152,7 +169,8 @@ try {
 $exe = Join-Path $BinDir $ExeName
 $installed = & $exe --version
 if ($LASTEXITCODE -ne 0) { throw "$exe was installed but will not run" }
-Write-Output "installed $installed to $exe"
+Write-Output "$verb $installed $prep $exe"
+Write-Conflicts -Target $exe
 
 $pathAdded = $false
 if (-not $NoModifyPath) {

--- a/install.sh
+++ b/install.sh
@@ -282,7 +282,7 @@ If ${VERSION} was released moments ago its archives may still be uploading — r
 	preposition=to
 	if [ -e "${INSTALL_DIR}/${BIN_NAME}" ]; then
 		verb=updated
-		preposition=at
+		preposition='at'
 	fi
 	mv -f "${tmp}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}"
 

--- a/install.sh
+++ b/install.sh
@@ -166,6 +166,36 @@ end
 EOF
 }
 
+# same_file returns 0 when both paths name the same file. -ef is not POSIX
+# but every common sh has it; fall back to a plain string compare.
+same_file() {
+	[ "$1" = "$2" ] && return 0
+	[ "$1" -ef "$2" ] 2>/dev/null
+}
+
+# warn_conflicts reports other flagsmith binaries on PATH that may shadow
+# (or be shadowed by) the one just installed.
+warn_conflicts() {
+	_target="${INSTALL_DIR}/${BIN_NAME}"
+	_found=0
+	_seen=
+	_ifs_save=$IFS
+	IFS=:
+	for _dir in $PATH; do
+		[ -n "$_dir" ] || continue
+		case ":${_seen}:" in *:"${_dir}":*) continue ;; esac
+		_seen="${_seen}:${_dir}"
+		[ -x "${_dir}/${BIN_NAME}" ] || continue
+		same_file "${_dir}/${BIN_NAME}" "$_target" && continue
+		say "warning: another '${BIN_NAME}' is on your PATH at ${_dir}/${BIN_NAME}"
+		_found=1
+	done
+	IFS=$_ifs_save
+	if [ "$_found" = 1 ]; then
+		say "It may shadow ${_target} — uninstall it first ('npm uninstall -g flagsmith-cli' removes the old npm CLI), then run 'hash -r' or open a new shell."
+	fi
+}
+
 # add_ci_path makes the CLI available to later steps of a GitHub Actions job.
 # GITHUB_PATH does not expand variables, so write the resolved directory.
 add_ci_path() {
@@ -248,11 +278,18 @@ If ${VERSION} was released moments ago its archives may still be uploading — r
 	tar -xzf "${tmp}/${archive_name}" -C "$tmp" "$BIN_NAME"
 	mkdir -p "$INSTALL_DIR"
 	chmod 755 "${tmp}/${BIN_NAME}"
+	verb=installed
+	preposition=to
+	if [ -e "${INSTALL_DIR}/${BIN_NAME}" ]; then
+		verb=updated
+		preposition=at
+	fi
 	mv -f "${tmp}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}"
 
 	installed=$("${INSTALL_DIR}/${BIN_NAME}" --version 2>/dev/null) ||
 		err "${INSTALL_DIR}/${BIN_NAME} was installed but will not run — wrong platform?"
-	say "installed ${installed} to ${INSTALL_DIR}/${BIN_NAME}"
+	say "${verb} ${installed} ${preposition} ${INSTALL_DIR}/${BIN_NAME}"
+	warn_conflicts
 
 	if [ "$NO_MODIFY_PATH" != 1 ]; then
 		modify_path


### PR DESCRIPTION

Closes #75.

In this PR, we add the following installer script improvements:
- The installer detects existing `flagsmith` command, walks the `PATH` to identify each conflicting binary, and lists them with a warning.
- Reinstalling over existing `${INSTALL_DIR}/flagsmith` produces no warning, and the final message now distinguishes the two cases: `installed <version> to <path>` on first install, `updated <version> at <path>` when overwriting.

Fresh install with an old CLI still on `PATH`:

```
$ curl -fsSL https://get.flagsmith.com | sh
downloading flagsmith v2.0.0 (darwin/arm64)
installed flagsmith version 2.0.0 to /Users/alice/.local/bin/flagsmith
warning: another 'flagsmith' is on your PATH at /usr/local/bin/flagsmith
It may shadow /Users/alice/.local/bin/flagsmith — uninstall it first ('npm uninstall -g flagsmith-cli' removes the old npm CLI), then run 'hash -r' or open a new shell.

Run 'flagsmith init' to get started.
```

Re-running the installer over an existing v2 binary (the smooth update path — no warning):

```
$ curl -fsSL https://get.flagsmith.com | sh
downloading flagsmith v2.0.0 (darwin/arm64)
updated flagsmith version 2.0.0 at /Users/alice/.local/bin/flagsmith

Run 'flagsmith init' to get started.
```

