### PR TITLE
chore: Graduate to a stable 2.0.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,9 +4,6 @@
         ".": {
             "release-type": "go",
             "changelog-path": "CHANGELOG.md",
-            "versioning": "prerelease",
-            "prerelease": true,
-            "prerelease-type": "beta",
             "draft": false,
             "include-component-in-tag": false,
             "extra-files": [


### PR DESCRIPTION

Ditto.

When merging, make sure the squash commit has the `Release-As: 2.0.0` footer.
