### PR TITLE
fix(ci): Homebrew cask ships no shell completions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,11 +68,13 @@ homebrew_casks:
       - flagsmith
     generate_completions_from_executable:
       executable: flagsmith
-      args: [completion]
+      # shell_parameter_format: cobra already passes `completion <shell>`.
       shell_parameter_format: cobra
       shells: [bash, zsh, fish]
     hooks:
-      post:
+      # Runs before the completions are generated, which the quarantined
+      # binary can't survive.
+      pre:
         # Homebrew quarantines what it downloads;
         # Unqarantine manually until we start notarising the Mac binaries.
         install: |


### PR DESCRIPTION
`brew install Flagsmith/tap/flagsmith` installs a working CLI, but every completion script fails to generate:

```
Failed to generate bash completions from /opt/homebrew/Caskroom/flagsmith/2.0.0/flagsmith:
Failure while executing; `{"SHELL" => "bash"} .../flagsmith completion completion bash`
was terminated by uncaught signal KILL.
```

In this PR, we fix two failures contributing to the error:
1. `shell_parameter_format: cobra` already makes Homebrew pass `completion <shell>` (`Library/Homebrew/utils/shell_completion.rb`), so our own `args: [completion]` produces `flagsmith completion completion bash`. That prints the help text and generates nothing.
2. The binary is still quarantined when the completions are generated.

### Verification

`goreleaser release --snapshot` now emits `preflight do` and a bare `generate_completions_from_executable "flagsmith"`. Installing that cask through a scratch local tap gives a clean install with no warnings and all three files present:

- `/opt/homebrew/share/zsh/site-functions/_flagsmith`
- `/opt/homebrew/etc/bash_completion.d/flagsmith`
- `/opt/homebrew/share/fish/vendor_completions.d/flagsmith.fish`

The quarantine half is directly reproducible:

```
$ xattr -w com.apple.quarantine "0081;00000000;Safari;" flagsmith && ./flagsmith completion bash
Killed: 9
$ xattr -d com.apple.quarantine flagsmith && ./flagsmith completion bash    # exit 0
```

Both faults go away for good once we notarise the macOS binaries (#85), at which point the un-quarantine hook can be dropped entirely.
