### PR TITLE
fix(docs): Command reference hides the sidebar on leaf pages

### DIFF
--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -64,7 +64,7 @@ func write(cmd *cobra.Command, dir string) error {
 	if err := doc.GenMarkdownCustom(cmd, &body, linker(cmd)); err != nil {
 		return err
 	}
-	page.Write(dropHeading(body.Bytes()))
+	page.Write(retitleSeeAlso(dropHeading(body.Bytes())))
 
 	// A command with subcommands owns a directory, so its page is that
 	// directory's index; a leaf is a plain page beside its siblings.
@@ -110,6 +110,12 @@ func linker(from *cobra.Command) func(string) string {
 		}
 		return filepath.ToSlash(rel) + "/"
 	}
+}
+
+// retitleSeeAlso rewrites cobra's shouty "SEE ALSO" heading to match the
+// sentence case of the headings around it.
+func retitleSeeAlso(md []byte) []byte {
+	return bytes.ReplaceAll(md, []byte("### SEE ALSO"), []byte("### See also"))
 }
 
 // dropHeading removes the "## <command path>" line cobra opens with, and the

--- a/cmd/docgen/main_test.go
+++ b/cmd/docgen/main_test.go
@@ -76,7 +76,29 @@ func TestWritePage(t *testing.T) {
 	assert.NotContains(t, got, "## flagsmith flag update")
 	// no generation date is stamped into the page
 	assert.NotContains(t, got, "Auto generated")
+	// cobra's shouty heading is sentence case, like the headings around it
+	assert.Contains(t, got, "### See also")
+	assert.NotContains(t, got, "SEE ALSO")
 
 	// Guard against the assertions above passing on an empty file.
 	require.NotEmpty(t, strings.TrimSpace(got))
+}
+
+func TestWriteCollapsesSidebarGroups(t *testing.T) {
+	// Given
+	dir := t.TempDir()
+	require.NoError(t, write(cmd.Root(), dir))
+
+	// When / Then
+	// the root of the tree is always expanded, so the top-level commands show
+	root, err := os.ReadFile(filepath.Join(dir, "_index.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(root), "sidebar:\n  open: true")
+
+	// everything below it is collapsed until the reader expands it
+	for _, page := range []string{"flag/_index.md", "environment/key/_index.md", "flag/update.md"} {
+		body, err := os.ReadFile(filepath.Join(dir, page))
+		require.NoError(t, err)
+		assert.NotContains(t, string(body), "sidebar:", page)
+	}
 }

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -12,7 +12,7 @@ module:
     - path: github.com/imfing/hextra
 
 cascade:
-  - _target: {}
+  - target: {}
     type: docs
 
 enableRobotsTXT: true

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -11,18 +11,11 @@ module:
   imports:
     - path: github.com/imfing/hextra
 
-# Every page in the site is part of the command reference, so give the whole of
-# content/ the theme's "docs" type. Without it the generated leaf pages (e.g.
-# organisation/delete) fall back to the theme's plain single-page layout, which
-# hides the sidebar, and the sidebar tree is rooted at the current top-level
-# section rather than at the whole command tree.
 cascade:
   - _target: {}
     type: docs
 
 enableRobotsTXT: true
-# Generated pages have no git history of their own, so there is no
-# "last modified" worth showing.
 enableGitInfo: false
 
 markup:
@@ -35,8 +28,6 @@ markup:
 
 menu:
   main:
-    # Installing is documented in the README and on docs.flagsmith.com. Link to
-    # one of them rather than keeping a third copy in step.
     - name: Install
       url: https://github.com/Flagsmith/flagsmith-cli#install
       weight: 1
@@ -62,13 +53,9 @@ params:
   footer:
     displayCopyright: false
     displayPoweredBy: false
-  # The reference is generated, so "edit this page" would point at a file that
-  # does not exist in the repository.
   editURL:
     enable: false
   page:
     width: normal
-  # Every page is a command, so the sidebar is the command tree and should be
-  # visible from the home page down.
   sidebar:
     displayTitle: false

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -11,6 +11,15 @@ module:
   imports:
     - path: github.com/imfing/hextra
 
+# Every page in the site is part of the command reference, so give the whole of
+# content/ the theme's "docs" type. Without it the generated leaf pages (e.g.
+# organisation/delete) fall back to the theme's plain single-page layout, which
+# hides the sidebar, and the sidebar tree is rooted at the current top-level
+# section rather than at the whole command tree.
+cascade:
+  - _target: {}
+    type: docs
+
 enableRobotsTXT: true
 # Generated pages have no git history of their own, so there is no
 # "last modified" worth showing.


### PR DESCRIPTION

In this PR, we address three issues found in https://flagsmith.github.io/flagsmith-cli/:

- the sidebar tree only ever showed the current top-level section.
- a leaf page such as https://flagsmith.github.io/flagsmith-cli/organisation/delete/ has no sidebar at all.
- the "SEE ALSO" heading is uppercase, unlike the "Examples" and "Options" headings around it.
